### PR TITLE
Update: update min-height to use --adapt-navigation-height var (fixes #16)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-navigationTitle",
   "version": "1.0.4",
-  "framework": ">=5.0.0",
+  "framework": ">=5.30.3",
   "homepage": "https://github.com/cgkineo/adapt-navigationTitle",
   "bugs": "https://github.com/cgkineo/adapt-navigationTitle/issues",
   "extension": "navigationTitle",

--- a/less/navigationTitle.less
+++ b/less/navigationTitle.less
@@ -1,10 +1,7 @@
 .navigation-title {
-  // nav min height based on known icon btn size (vars defined in core)
-  @navMinHeight: (@icon-padding * 2) + @icon-size;
-
   display: inline-flex;
   align-items: center;
-  min-height: @navMinHeight;
+  min-height: var(--adapt-navigation-height);
   padding-right: @icon-padding;
   padding-left: @icon-padding;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-navigationTitle",
   "version": "1.0.4",
-  "framework": ">=5.0.0",
+  "framework": ">=5.30.3",
   "homepage": "https://github.com/cgkineo/adapt-navigationTitle",
   "bugs": "https://github.com/cgkineo/adapt-navigationTitle/issues",
   "extension": "navigationTitle",


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-navigationTitle/issues/16

### Update
* Title `min-height` updated to use `--adapt-navigation-height` variable for consistency with other nav height styles used across plugins. For example [navigationLogo](https://github.com/cgkineo/adapt-navigationLogo/blob/e13ed387045eccd8b05fb16049b004038b247ee3/less/navigationLogo.less#L14) and [Sideways](https://github.com/cgkineo/adapt-sideways/blob/c4132cd895c94173052d76640f3fe3b2d99bc0d7/less/variations.less#L63) etc.
* Change required FW version to 5.30.3 (The Navigation API was introduced in https://github.com/adaptlearning/adapt_framework/releases/tag/v5.30.3.)




